### PR TITLE
Adding option to load JWT key from dict

### DIFF
--- a/djangooidc/oidc.py
+++ b/djangooidc/oidc.py
@@ -227,6 +227,11 @@ class OIDCClients(object):
                 key_jar =keyio.KeyJar(verify_ssl=verify_ssl)
                 key_jar.add_kb("",key_bundle)
                 args["keyjar"] = key_jar
+            if "keyset_jwk_dict" in kwargs["client_registration"].keys():
+                kc_rsa = keyio.KeyBundle(kwargs["client_registration"]['keyset_jwk_dict'])
+                key_jar =keyio.KeyJar(verify_ssl=verify_ssl)
+                key_jar.add_kb("",kc_rsa)
+                args["keyjar"] = key_jar
 
         client = self.client_cls(client_authn_method=CLIENT_AUTHN_METHOD,
                                  behaviour=kwargs["behaviour"], verify_ssl=verify_ssl, **args)


### PR DESCRIPTION
Currently when loading the JWK it requires a key to be loaded from disk. This PR adds the option to load the key from a dict so it can be sourced from other locations such as an envar.

Below is an example:
```
from authlib.jose import jwk
key_dict = jwk.dumps(os.environ["SECRET_KEY"], kty="RSA")
key_dict["use"] = "sig"
key_dict["alg"] = "RS256"
key_dict["kid"] = os.environ["KID_JWK"]

 # Set up our providers.
 OIDC_PROVIDERS = {
             "token_endpoint_auth_method": ["private_key_jwt"],
             "enc_kid": os.environ["KID_JWK"],
-            "keyset_jwk_file": "file://+ os.path.join(BASE_DIR, "keys", os.environ["JWK_SET_FILENAME"]),
+            "keyset_jwt_dict": key_dict,

```